### PR TITLE
criação dos testes e implementação do PacienteService - issue#25

### DIFF
--- a/ProjetoIntegrador/pom.xml
+++ b/ProjetoIntegrador/pom.xml
@@ -45,7 +45,22 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-    </dependencies>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.13.4</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+			<version>2.13.4</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
+			<version>2.13.4</version>
+		</dependency>
+	</dependencies>
 
 	<build>
 		<plugins>

--- a/ProjetoIntegrador/src/main/java/com/checkPoint/ProjetoIntegrador/Exception/ExceptionClinicaOdontologica.java
+++ b/ProjetoIntegrador/src/main/java/com/checkPoint/ProjetoIntegrador/Exception/ExceptionClinicaOdontologica.java
@@ -1,0 +1,16 @@
+package com.checkPoint.ProjetoIntegrador.Exception;
+
+public class ExceptionClinicaOdontologica extends RuntimeException{
+
+    public ExceptionClinicaOdontologica() {
+    }
+
+    public ExceptionClinicaOdontologica(String message) {
+        super(message);
+    }
+
+    @Override
+    public String toString() {
+        return "ExceptionPaciente{}";
+    }
+}

--- a/ProjetoIntegrador/src/main/java/com/checkPoint/ProjetoIntegrador/dto/PacienteDTO.java
+++ b/ProjetoIntegrador/src/main/java/com/checkPoint/ProjetoIntegrador/dto/PacienteDTO.java
@@ -1,5 +1,16 @@
 package com.checkPoint.ProjetoIntegrador.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.*;
+
+@ToString
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PacienteDTO {
-    //TODO
+    private String nome;
+    private String sobrenome;
+
 }

--- a/ProjetoIntegrador/src/main/java/com/checkPoint/ProjetoIntegrador/model/EnderecoPaciente.java
+++ b/ProjetoIntegrador/src/main/java/com/checkPoint/ProjetoIntegrador/model/EnderecoPaciente.java
@@ -1,5 +1,6 @@
 package com.checkPoint.ProjetoIntegrador.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 
 import javax.persistence.*;
@@ -34,8 +35,5 @@ public class EnderecoPaciente {
     @NonNull
     @Column(nullable = false, length = 50)
     private String estado;
-
-    @OneToOne(mappedBy = "enderecoPaciente")
-    private Paciente paciente;
 
 }

--- a/ProjetoIntegrador/src/main/java/com/checkPoint/ProjetoIntegrador/model/Paciente.java
+++ b/ProjetoIntegrador/src/main/java/com/checkPoint/ProjetoIntegrador/model/Paciente.java
@@ -1,5 +1,7 @@
 package com.checkPoint.ProjetoIntegrador.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.*;
 
 import java.util.List;
@@ -31,7 +33,6 @@ public class Paciente {
     @Column(nullable = false, length = 10)
     private String rg;
 
-    @NonNull
     private LocalDate dataAlta;
 
     @NonNull
@@ -39,7 +40,8 @@ public class Paciente {
     @JoinColumn(name = "idEndereco")
     private EnderecoPaciente enderecoPaciente;
 
-    @OneToMany(mappedBy = "paciente", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "paciente")
+    @JsonIgnore
     private List<Consulta> consultas;
 
 }

--- a/ProjetoIntegrador/src/main/java/com/checkPoint/ProjetoIntegrador/service/PacienteService.java
+++ b/ProjetoIntegrador/src/main/java/com/checkPoint/ProjetoIntegrador/service/PacienteService.java
@@ -1,5 +1,44 @@
 package com.checkPoint.ProjetoIntegrador.service;
 
+import com.checkPoint.ProjetoIntegrador.Exception.ExceptionClinicaOdontologica;
+import com.checkPoint.ProjetoIntegrador.dto.PacienteDTO;
+import com.checkPoint.ProjetoIntegrador.model.Paciente;
+import com.checkPoint.ProjetoIntegrador.repository.IPacienteRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
 public class PacienteService {
-    //TODO
+    @Autowired
+    IPacienteRepository pacienteRepository;
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    PacienteDTO pacienteDTO;
+
+    public PacienteDTO criarPaciente(Paciente paciente)  {
+        if(paciente == null){
+            throw new ExceptionClinicaOdontologica("Dados não informados, ou faltantes, tente novamente!");
+        }
+        paciente = pacienteRepository.save(paciente);
+        //objectMapper.findAndRegisterModules(); Chama os módulos reponsáveis de interpretar o LocalDate para o jackson
+        pacienteDTO =  objectMapper.convertValue(paciente, PacienteDTO.class);
+        return pacienteDTO;
+    }
+
+    public PacienteDTO buscarPacienteById(Integer idPaciente){
+        pacienteDTO = objectMapper.convertValue(pacienteRepository.findById(idPaciente).orElseThrow(
+                ()-> new ExceptionClinicaOdontologica("Paciente não encontrado!")), PacienteDTO.class);
+        return pacienteDTO;
+    }
+
+    public boolean existePacienteById(Integer idPaciente){
+        return pacienteRepository.existsById(idPaciente);
+    }
+
+    public void deletarPacienteById(Integer idPaciente){
+        pacienteRepository.deleteById(idPaciente);
+    }
+
+
 }

--- a/ProjetoIntegrador/src/main/resources/application.properties
+++ b/ProjetoIntegrador/src/main/resources/application.properties
@@ -6,6 +6,5 @@ spring.jpa.hibernate.ddl-auto=create-drop
 
 #Configurações a serem estudadas, implementadas ao excluidas
 #spring.sql.init.platform = h2
-#spring.h2.console.enable = true
 #spring.datasource.username =""
 #spring.datasource.password =""

--- a/ProjetoIntegrador/src/test/java/com/checkPoint/ProjetoIntegrador/model/ConsultaTest.java
+++ b/ProjetoIntegrador/src/test/java/com/checkPoint/ProjetoIntegrador/model/ConsultaTest.java
@@ -20,7 +20,7 @@ public class ConsultaTest {
     public void iniciaConsulta(){
         dentista = new Dentista("Lorivaldo", "Silva", "D-SP: 3907");
         enderecoPaciente = new EnderecoPaciente("Rua Anne Frank", 3050, "84567-211", "Laguna", "Santa Catarina");
-        paciente = new Paciente("Josivaldo", "Souza", "68945644", LocalDate.now(), enderecoPaciente);
+        paciente = new Paciente("Josivaldo", "Souza", "68945644", enderecoPaciente);
         consulta = new Consulta(paciente, dentista, LocalDateTime.now());
     }
 

--- a/ProjetoIntegrador/src/test/java/com/checkPoint/ProjetoIntegrador/model/PacienteTest.java
+++ b/ProjetoIntegrador/src/test/java/com/checkPoint/ProjetoIntegrador/model/PacienteTest.java
@@ -17,7 +17,7 @@ public class PacienteTest {
     public void iniciaPaciente(){
         enderecoPaciente = new EnderecoPaciente("Rua Anne Frank", 3050, "84567-211", "Laguna", "Santa Catarina");
 
-        paciente = new Paciente("Josivaldo", "Souza", "68945644", LocalDate.now(), enderecoPaciente);
+        paciente = new Paciente("Josivaldo", "Souza", "68945644", enderecoPaciente);
     }
 
     @Test

--- a/ProjetoIntegrador/src/test/java/com/checkPoint/ProjetoIntegrador/repository/ConsultaTest.java
+++ b/ProjetoIntegrador/src/test/java/com/checkPoint/ProjetoIntegrador/repository/ConsultaTest.java
@@ -23,7 +23,7 @@ public class ConsultaTest {
     @Test
     public void criarConsulta(){
         EnderecoPaciente enderecoPaciente = new EnderecoPaciente("Rua embaixador valadares", 3456, "23456-211", "Rio de Janeiro", "Rio de janeiro");
-        Paciente paciente1 = new Paciente("João", "Sousa","255635271",LocalDate.of(2018, 6,24), enderecoPaciente);
+        Paciente paciente1 = new Paciente("João", "Sousa","255635271", enderecoPaciente);
         Dentista dentista = new Dentista ("Ewerton", "Lopes", "CRO-125987");
         this.consulta = new Consulta(paciente1, dentista, LocalDateTime.of(2020, 06,23,14,30));
         consultaSalvo = iConsultaRepository.save(consulta);
@@ -44,7 +44,7 @@ public class ConsultaTest {
     @Test
     public void buscarConsulta(){
         EnderecoPaciente enderecoPaciente = new EnderecoPaciente("Rua embaixador valadares", 3456, "23456-211", "Rio de Janeiro", "Rio de janeiro");
-        Paciente paciente1 = new Paciente("João", "Sousa","255635271",LocalDate.of(2018, 6,24), enderecoPaciente);
+        Paciente paciente1 = new Paciente("João", "Sousa","255635271", enderecoPaciente);
         Dentista dentista = new Dentista ("Ewerton", "Lopes", "CRO-125987");
         this.consulta = new Consulta(paciente1, dentista, LocalDateTime.of(2020, 06,23,14,30));
 
@@ -56,7 +56,7 @@ public class ConsultaTest {
     @Test
     public void atualizarConsulta(){
         EnderecoPaciente enderecoPaciente = new EnderecoPaciente("Rua embaixador valadares", 3456, "23456-211", "Rio de Janeiro", "Rio de janeiro");
-        Paciente paciente1 = new Paciente("João", "Sousa","255635271",LocalDate.of(2018, 6,24), enderecoPaciente);
+        Paciente paciente1 = new Paciente("João", "Sousa","255635271", enderecoPaciente);
         Dentista dentista = new Dentista ("Ewerton", "Lopes", "CRO-125987");
         this.consulta = new Consulta(paciente1, dentista, LocalDateTime.of(2020, 06,23,14,30));
 
@@ -69,7 +69,7 @@ public class ConsultaTest {
     @Test
     public void deletarConsulta(){
         EnderecoPaciente enderecoPaciente = new EnderecoPaciente("Rua embaixador valadares", 3456, "23456-211", "Rio de Janeiro", "Rio de janeiro");
-        Paciente paciente1 = new Paciente("João", "Sousa","255635271",LocalDate.of(2018, 6,24), enderecoPaciente);
+        Paciente paciente1 = new Paciente("João", "Sousa","255635271", enderecoPaciente);
         Dentista dentista = new Dentista ("Ewerton", "Lopes", "CRO-125987");
         this.consulta = new Consulta(paciente1, dentista, LocalDateTime.of(2020, 06,23,14,30));
         consultaSalvo = iConsultaRepository.save(consulta);

--- a/ProjetoIntegrador/src/test/java/com/checkPoint/ProjetoIntegrador/repository/PacienteTest.java
+++ b/ProjetoIntegrador/src/test/java/com/checkPoint/ProjetoIntegrador/repository/PacienteTest.java
@@ -25,7 +25,7 @@ public class PacienteTest {
     public void criarPaciente(){
         this.enderecoPaciente = new EnderecoPaciente("Benjamin Constant", 243, "11040140", "Santos", "São Paulo");
         enderecoPacienteSalvo = this.iEnderecoPacienteRepository.save(enderecoPaciente);
-        this.paciente = new Paciente("Daniel", "Martins", "44444444", LocalDate.of(2022,9,9), iEnderecoPacienteRepository.findById(enderecoPacienteSalvo.getIdEndereco()).get());
+        this.paciente = new Paciente("Daniel", "Martins", "44444444", iEnderecoPacienteRepository.findById(enderecoPacienteSalvo.getIdEndereco()).get());
         pacienteSalvo = pacienteRepository.save(paciente);
         Assertions.assertNotNull(this.pacienteSalvo.getIdPaciente());
         Assertions.assertEquals(this.paciente.getNome(),this.pacienteSalvo.getNome());
@@ -39,7 +39,7 @@ public class PacienteTest {
     public void buscaPaciente(){
         this.enderecoPaciente = new EnderecoPaciente("Benjamin Constant", 243, "11040140", "Santos", "São Paulo");
         enderecoPacienteSalvo = this.iEnderecoPacienteRepository.save(enderecoPaciente);
-        this.paciente = new Paciente("Daniel", "Martins", "44444444", LocalDate.of(2022,9,9), iEnderecoPacienteRepository.findById(enderecoPacienteSalvo.getIdEndereco()).get());
+        this.paciente = new Paciente("Daniel", "Martins", "44444444", iEnderecoPacienteRepository.findById(enderecoPacienteSalvo.getIdEndereco()).get());
         pacienteSalvo = pacienteRepository.save(paciente);
         Assertions.assertTrue(this.pacienteRepository.findById(this.pacienteSalvo.getIdPaciente()).isPresent());
     }
@@ -48,7 +48,7 @@ public class PacienteTest {
     public void atualizaPaciente(){
         this.enderecoPaciente = new EnderecoPaciente("Benjamin Constant", 243, "11040140", "Santos", "São Paulo");
         enderecoPacienteSalvo = this.iEnderecoPacienteRepository.save(enderecoPaciente);
-        this.paciente = new Paciente("Daniel", "Martins", "44444444", LocalDate.of(2022,9,9), iEnderecoPacienteRepository.findById(enderecoPacienteSalvo.getIdEndereco()).get());
+        this.paciente = new Paciente("Daniel", "Martins", "44444444", iEnderecoPacienteRepository.findById(enderecoPacienteSalvo.getIdEndereco()).get());
         pacienteSalvo = pacienteRepository.save(paciente);
         this.pacienteSalvo.setNome("Lucas");
         this.pacienteSalvo.setRg("55555555");
@@ -62,7 +62,7 @@ public class PacienteTest {
     public void deletaPaciente(){
         this.enderecoPaciente = new EnderecoPaciente("Benjamin Constant", 243, "11040140", "Santos", "São Paulo");
         enderecoPacienteSalvo = this.iEnderecoPacienteRepository.save(enderecoPaciente);
-        this.paciente = new Paciente("Daniel", "Martins", "44444444", LocalDate.of(2022,9,9), iEnderecoPacienteRepository.findById(enderecoPacienteSalvo.getIdEndereco()).get());
+        this.paciente = new Paciente("Daniel", "Martins", "44444444", iEnderecoPacienteRepository.findById(enderecoPacienteSalvo.getIdEndereco()).get());
         pacienteSalvo = pacienteRepository.save(paciente);
         this.pacienteRepository.deleteById(this.pacienteSalvo.getIdPaciente());
         Assertions.assertFalse(this.pacienteRepository.findById(this.pacienteSalvo.getIdPaciente()).isPresent());

--- a/ProjetoIntegrador/src/test/java/com/checkPoint/ProjetoIntegrador/service/PacienteServiceTest.java
+++ b/ProjetoIntegrador/src/test/java/com/checkPoint/ProjetoIntegrador/service/PacienteServiceTest.java
@@ -1,0 +1,46 @@
+package com.checkPoint.ProjetoIntegrador.service;
+
+import com.checkPoint.ProjetoIntegrador.dto.PacienteDTO;
+import com.checkPoint.ProjetoIntegrador.model.EnderecoPaciente;
+import com.checkPoint.ProjetoIntegrador.model.Paciente;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class PacienteServiceTest {
+
+    @Autowired
+    PacienteService pacienteService;
+
+    @Test
+    public void criarPacienteServiceTest(){
+        EnderecoPaciente  enderecoPaciente = new EnderecoPaciente("Benjamin Constant", 243,
+                "11040140", "Santos", "São Paulo");
+        Paciente paciente = new Paciente("Daniel", "Martins", "44444444", enderecoPaciente);;
+        Assertions.assertEquals("Daniel", pacienteService.criarPaciente(paciente).getNome());
+        Assertions.assertEquals("Martins", pacienteService.criarPaciente(paciente).getSobrenome());
+    }
+
+    @Test
+    public void buscarPacienteById(){
+        EnderecoPaciente  enderecoPaciente = new EnderecoPaciente("Benjamin Constant", 243,
+                "11040140", "Santos", "São Paulo");
+        Paciente pacienteModel = new Paciente("Daniel", "Martins", "44444444", enderecoPaciente);
+        pacienteService.criarPaciente(pacienteModel);
+        PacienteDTO pacienteDTO = pacienteService.buscarPacienteById(1);
+        Assertions.assertNotNull(pacienteDTO);
+    }
+
+    @Test
+    public void deletarPacienteById(){
+        EnderecoPaciente  enderecoPaciente = new EnderecoPaciente("Benjamin Constant", 243,
+                "11040140", "Santos", "São Paulo");
+        Paciente pacienteModel = new Paciente("Daniel", "Martins", "44444444", enderecoPaciente);
+        pacienteService.criarPaciente(pacienteModel);
+        pacienteService.deletarPacienteById(pacienteModel.getIdPaciente());
+        pacienteService.buscarPacienteById(pacienteModel.getIdPaciente());
+    }
+
+}


### PR DESCRIPTION
#### Criação do teste de Service e Implementação do Service (regras de negócio) da entidade Paciente; #25

  - Ao tentar converter pacienteModel em pacienteDTO estava ocorrendo erro pois o jacksson não interpreta o LocalDate. Duas soluções: 
     - [x] 1° tirar dataAlta do construtor (uma vez que não tem lógica de mantê-la);
     - [ ] 2° adicionar a dependência do jackson no arquivo pom.xml para ele aceitar o LocalDate e chamar os módulos com a seguinte linha antes da conversão "objectMapper.findAndRegisterModules( );"
      *  Optei pela primeira, mas deixei a dependência e o comentário necessário para a segunda opção em caso de uso futuro
 
 - Mudança da ExceptionPaciente para ExceptionClinicaOdontologica para reutiliza-la em vários pontos da aplicação;


 - Retirada do atributo: 
 ``` 
    @OneToOne(mappedBy = "enderecoPaciente")
    @JsonIgnore
    private Paciente paciente;
```
<sub>da **Entity EnderecoPaciente**, pois o mesmo denotava um relacionamento bidirecional, e em nosso UML temos uma relação unidirecional;</sub>

 - Adição da annotation @JsonIgnore sobre o atributo List de Consultas em pacienteModel, para o hibernate ignorar o mesmo e o ObjectMapper consiga convertê-lo em pacienteDTO;